### PR TITLE
Use instanced mesh for balls

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -236,7 +236,7 @@ function onSelectStart(evt) {
 // ==============================
 // Schüsse / Bälle
 // ==============================
-const balls = []; // { mesh, body, bornAt, noCollideUntil }
+const balls = []; // { index, body, bornAt, noCollideUntil }
 const BALL_RADIUS   = 0.02;
 const BALL_MASS     = 0.003;
 const BALL_SPEED    = 3.5;
@@ -247,18 +247,36 @@ const sharedBallGeometry = new THREE.SphereGeometry(BALL_RADIUS, 16, 12);
 const sharedBallMaterial = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.8, metalness: 0.0 });
 const sharedBallShape = new CANNON.Sphere(BALL_RADIUS);
 
+// Instanced mesh for all balls
+const ballMesh = new THREE.InstancedMesh(sharedBallGeometry, sharedBallMaterial, BALL_LIMIT);
+ballMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+scene.add(ballMesh);
+
+// Transform storage and free-slot recycling
+const ballTransforms = Array(BALL_LIMIT).fill(null);
+const freeBallIndices = [];
+let nextBallIndex = 0;
+const _ballScale = new THREE.Vector3(1, 1, 1);
+const _hiddenMatrix = new THREE.Matrix4().makeScale(0, 0, 0);
+
 function syncMeshesFromPhysics() {
   for (let i = 0; i < balls.length; i++) {
-    const { mesh, body } = balls[i];
-    mesh.position.copy(body.position);
-    mesh.quaternion.copy(body.quaternion);
+    const { index, body } = balls[i];
+    let m = ballTransforms[index];
+    if (!m) {
+      m = new THREE.Matrix4();
+      ballTransforms[index] = m;
+    }
+    m.compose(body.position, body.quaternion, _ballScale);
+    ballMesh.setMatrixAt(index, m);
   }
+  ballMesh.instanceMatrix.needsUpdate = true;
 }
 
 function spawnBall(origin, dir) {
   if (balls.length >= BALL_LIMIT) removeBall(balls[0]);
-  const mesh = new THREE.Mesh(sharedBallGeometry, sharedBallMaterial);
-  scene.add(mesh);
+
+  const index = freeBallIndices.length ? freeBallIndices.pop() : nextBallIndex++;
 
   const body = new CANNON.Body({ mass: BALL_MASS, material: matBall });
   body.addShape(sharedBallShape);
@@ -275,17 +293,28 @@ function spawnBall(origin, dir) {
 
   world.addBody(body);
 
+  const m = new THREE.Matrix4();
+  m.compose(body.position, body.quaternion, _ballScale);
+  ballMesh.setMatrixAt(index, m);
+  ballTransforms[index] = m;
+  ballMesh.instanceMatrix.needsUpdate = true;
+
   const now = performance.now();
-  const item = { mesh, body, bornAt: now, noCollideUntil: now + BALL_NO_COLLISION_MS };
+  const item = { index, body, bornAt: now, noCollideUntil: now + BALL_NO_COLLISION_MS };
   balls.push(item);
   return item;
 }
 
 function removeBall(item) {
-  scene.remove(item.mesh);
   world.removeBody(item.body);
   const i = balls.indexOf(item);
   if (i !== -1) balls.splice(i, 1);
+
+  const idx = item.index;
+  ballTransforms[idx] = null;
+  ballMesh.setMatrixAt(idx, _hiddenMatrix);
+  ballMesh.instanceMatrix.needsUpdate = true;
+  freeBallIndices.push(idx);
 }
 
 function clearAllBalls() {


### PR DESCRIPTION
## Summary
- switch ball rendering to a single `THREE.InstancedMesh`
- track transforms and recycle instance indices when spawning/removing balls
- keep physics bodies mapped to instanced mesh indices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e7e804e8832eb187c2fc3082a1d0