### PR TITLE
Initialize and update instanced mesh draw count

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -251,6 +251,7 @@ const sharedBallShape = new CANNON.Sphere(BALL_RADIUS);
 const ballMesh = new THREE.InstancedMesh(sharedBallGeometry, sharedBallMaterial, BALL_LIMIT);
 ballMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
 scene.add(ballMesh);
+ballMesh.count = 0;
 
 // Transform storage and free-slot recycling
 const ballTransforms = Array(BALL_LIMIT).fill(null);
@@ -296,6 +297,7 @@ function spawnBall(origin, dir) {
   const m = new THREE.Matrix4();
   m.compose(body.position, body.quaternion, _ballScale);
   ballMesh.setMatrixAt(index, m);
+  ballMesh.count = Math.max(ballMesh.count, index + 1);
   ballTransforms[index] = m;
   ballMesh.instanceMatrix.needsUpdate = true;
 


### PR DESCRIPTION
## Summary
- Initialize `ballMesh.count` to zero so no balls are rendered until spawned
- Expand `spawnBall` to update `ballMesh.count` based on highest instance index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ea17fa84832e8e0ee4f976b39427